### PR TITLE
🩹 fix: key removal in signin

### DIFF
--- a/backend/identity/internal/services/signin.go
+++ b/backend/identity/internal/services/signin.go
@@ -58,7 +58,7 @@ func (s *SignInService) SignIn(ctx context.Context, signInKey uuid.UUID, code st
 	}
 
 	if err := s.storage.Remove(ctx, signInKey); err != nil {
-		// TODO: log it
+		return jwt.Pair{}, fmt.Errorf("sign in key removal failed: %s", err)
 	}
 
 	return pair, nil


### PR DESCRIPTION
If sign in metadata has not be removed from the storage after signing in then we can't be sure that same sign in key and code won't be able to sign in again successfully. It is a safety problem.